### PR TITLE
circleci環境のdockerイメージをローカル環境と統一

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.15.3-jessie
+      - image: fsninomiya/kinshai-gatsbyjs
     environment:
       TZ: Asia/Tokyo
     working_directory: ~/repo
@@ -18,7 +18,6 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: yarn global add gatsby-cli
       - run: yarn install
 
       - save_cache:


### PR DESCRIPTION
circleciで使用するdocker image をローカル環境で使っているものと同じようにdockerhubからimageを持ってくるように変更しました。
これで実質、ローカルとcircleciの自動テストのベース環境は同一になりました！